### PR TITLE
Fixed test shouldOpenCircuitBreakerAndCloseAfterSleepTime

### DIFF
--- a/feign-reactor-cloud/src/test/java/reactivefeign/cloud/HystrixReactiveHttpClientTest.java
+++ b/feign-reactor-cloud/src/test/java/reactivefeign/cloud/HystrixReactiveHttpClientTest.java
@@ -1,12 +1,11 @@
 package reactivefeign.cloud;
 
-import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import com.netflix.hystrix.*;
 import com.netflix.hystrix.exception.HystrixRuntimeException;
 import feign.MethodMetadata;
 import feign.Target;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -38,8 +37,8 @@ public class HystrixReactiveHttpClientTest {
     public static final String FALLBACK = "fallback";
     public static final String SUCCESS = "success!";
     public static final int UPDATE_INTERVAL = 5;
-    @ClassRule
-    public static WireMockClassRule server = new WireMockClassRule(wireMockConfig().dynamicPort());
+    @Rule
+    public static WireMockRule server = new WireMockRule(wireMockConfig().dynamicPort());
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();

--- a/feign-reactor-cloud/src/test/java/reactivefeign/cloud/LoadBalancingReactiveHttpClientTest.java
+++ b/feign-reactor-cloud/src/test/java/reactivefeign/cloud/LoadBalancingReactiveHttpClientTest.java
@@ -1,5 +1,6 @@
 package reactivefeign.cloud;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import com.netflix.client.*;
@@ -228,7 +229,7 @@ public class LoadBalancingReactiveHttpClientTest {
                         .withBody(body)));
     }
 
-    static void mockSuccessAfterSeveralAttempts(WireMockClassRule server, String url,
+    static void mockSuccessAfterSeveralAttempts(WireMockServer server, String url,
                                                 int failedAttemptsNo, int errorCode, ResponseDefinitionBuilder response) {
         String state = STARTED;
         for (int attempt = 0; attempt < failedAttemptsNo; attempt++) {


### PR DESCRIPTION
Root cause:
WireMockClassRule starts service per class and doesn't refresh it.
All stubs are still exists, so if different tests use the same endpoint,
it causes to unexpected results. In this case one of the tests checks
the number of invoked stubs in test and fails, because server returns all stubs in the suite.

In contrast, WireMockRule reloads context before each test

Resolution summary:
change WireMockClassRule to WireMockRule