### PR TITLE
fixes Can't customize the ObjectMapper used by feign-reactor-webclient #49

### DIFF
--- a/feign-reactor-spring-configuration/src/main/java/reactivefeign/spring/config/ReactiveFeignClientsConfiguration.java
+++ b/feign-reactor-spring-configuration/src/main/java/reactivefeign/spring/config/ReactiveFeignClientsConfiguration.java
@@ -25,12 +25,13 @@ import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.cloud.netflix.ribbon.SpringClientFactory;
+import org.springframework.cloud.client.loadbalancer.reactive.WebClientCustomizer;
 import org.springframework.cloud.openfeign.support.SpringMvcContract;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Scope;
+import org.springframework.web.reactive.function.client.WebClient;
 import reactivefeign.ReactiveFeignBuilder;
 import reactivefeign.cloud.CloudReactiveFeign;
 import reactivefeign.webclient.WebReactiveFeign;
@@ -51,9 +52,27 @@ public class ReactiveFeignClientsConfiguration {
 	@Bean
 	@Scope("prototype")
 	@ConditionalOnClass(WebReactiveFeign.class)
+	@ConditionalOnMissingBean
+	public WebClientCustomizer webClientCustomizer() {
+		return webClientBuilder -> {};
+	}
+
+	@Bean
+	@Scope("prototype")
+	@ConditionalOnClass(WebReactiveFeign.class)
+	@ConditionalOnMissingBean
+	public WebClient webClient(WebClientCustomizer webClientCustomizer) {
+		WebClient.Builder builder = WebClient.builder();
+		webClientCustomizer.customize(builder);
+		return builder.build();
+	}
+
+	@Bean
+	@Scope("prototype")
+	@ConditionalOnClass(WebReactiveFeign.class)
 	@ConditionalOnMissingBean(ignoredType = "reactivefeign.cloud.CloudReactiveFeign.Builder")
-	public ReactiveFeignBuilder reactiveFeignBuilder() {
-		return WebReactiveFeign.builder();
+	public ReactiveFeignBuilder reactiveFeignBuilder(WebClient webClient) {
+		return WebReactiveFeign.builder(webClient);
 	}
 
 	@AutoConfigureAfter(ReactiveFeignClientsConfiguration.class)

--- a/feign-reactor-test/feign-reactor-spring-configuration-test/src/test/java/reactivefeign/spring/config/AutoConfigurationTest.java
+++ b/feign-reactor-test/feign-reactor-spring-configuration-test/src/test/java/reactivefeign/spring/config/AutoConfigurationTest.java
@@ -26,9 +26,9 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.client.loadbalancer.reactive.WebClientCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -54,6 +54,8 @@ public class AutoConfigurationTest {
 	private static final String TEST_URL = "/testUrl";
 	private static final String BODY_TEXT = "test";
 	private static final String FALLBACK_TEXT = "test fallback";
+	public static final String CUSTOM = "custom";
+	public static final String HEADER = "header";
 	private static WireMockServer mockHttpServer = new WireMockServer(wireMockConfig().dynamicPort());
 
 	@Autowired
@@ -62,6 +64,7 @@ public class AutoConfigurationTest {
 	@Test
 	public void shouldReturnBody() {
 		mockHttpServer.stubFor(WireMock.get(WireMock.urlPathMatching(TEST_URL))
+				.withHeader(CUSTOM, equalTo(HEADER))
 				.willReturn(WireMock.aResponse()
 						.withBody(BODY_TEXT)));
 		Mono<String> result = feignClient.testMethod();
@@ -74,6 +77,7 @@ public class AutoConfigurationTest {
 	@Test
 	public void shouldReturnFallbackOnError() {
 		mockHttpServer.stubFor(get(urlPathMatching(TEST_URL))
+				.withHeader(CUSTOM, equalTo(HEADER))
 				.willReturn(aResponse()
 						.withStatus(598)));
 
@@ -126,6 +130,13 @@ public class AutoConfigurationTest {
 		@Bean
 		public TestFallback reactiveFallback(){
 			return new TestFallback();
+		}
+
+		@Bean
+		public WebClientCustomizer webClientCustomizer(){
+			return webClientBuilder -> {
+				webClientBuilder.defaultHeader(CUSTOM, HEADER);
+			};
 		}
 	}
 }


### PR DESCRIPTION
add 2 options to configure WebClient:
- WebClient bean
- WebClientCustomizer bean

