### PR TITLE
Fix: Current Webclient implementation is unsupported by versions prior to Spring 5.2

### DIFF
--- a/feign-reactor-webclient/src/main/java/reactivefeign/webclient/client/WebReactiveHttpResponse.java
+++ b/feign-reactor-webclient/src/main/java/reactivefeign/webclient/client/WebReactiveHttpResponse.java
@@ -62,12 +62,14 @@ class WebReactiveHttpResponse<P extends Publisher<?>> implements ReactiveHttpRes
 	public Mono<byte[]> bodyData() {
 		Flux<DataBuffer> response = clientResponse.body(BodyExtractors.toDataBuffers());
 		return DataBufferUtils.join(response)
-				.map(dataBuffer -> {
-					byte[] result = new byte[dataBuffer.readableByteCount()];
-					dataBuffer.read(result);
-					DataBufferUtils.release(dataBuffer);
-					return result;
-				})
+				.map(WebReactiveHttpResponse::readToByteArray)
 				.defaultIfEmpty(new byte[0]);
+	}
+
+	private static byte[] readToByteArray(DataBuffer dataBuffer) {
+		byte[] result = new byte[dataBuffer.readableByteCount()];
+		dataBuffer.read(result);
+		DataBufferUtils.release(dataBuffer);
+		return result;
 	}
 }

--- a/feign-reactor-webclient/src/main/java/reactivefeign/webclient/client/WebReactiveHttpResponse.java
+++ b/feign-reactor-webclient/src/main/java/reactivefeign/webclient/client/WebReactiveHttpResponse.java
@@ -2,8 +2,6 @@ package reactivefeign.webclient.client;
 
 import org.reactivestreams.Publisher;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.core.ResolvableType;
-import org.springframework.core.codec.ByteArrayDecoder;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.web.reactive.function.BodyExtractors;
@@ -24,7 +22,6 @@ class WebReactiveHttpResponse<P extends Publisher<?>> implements ReactiveHttpRes
 	private final Type returnPublisherType;
 	private final ParameterizedTypeReference returnActualType;
 
-	private final ByteArrayDecoder byteArrayDecoder = new ByteArrayDecoder();
 
 	WebReactiveHttpResponse(ReactiveHttpRequest reactiveRequest,
 							ClientResponse clientResponse,
@@ -65,7 +62,12 @@ class WebReactiveHttpResponse<P extends Publisher<?>> implements ReactiveHttpRes
 	public Mono<byte[]> bodyData() {
 		Flux<DataBuffer> response = clientResponse.body(BodyExtractors.toDataBuffers());
 		return DataBufferUtils.join(response)
-				.map(dataBuffer -> byteArrayDecoder.decode(dataBuffer, ResolvableType.NONE, null, null))
+				.map(dataBuffer -> {
+					byte[] result = new byte[dataBuffer.readableByteCount()];
+					dataBuffer.read(result);
+					DataBufferUtils.release(dataBuffer);
+					return result;
+				})
 				.defaultIfEmpty(new byte[0]);
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Playtika/feign-reactive/issues/228

I have inlined a very simple method that is causing an error in earlier Spring 5 versions, because it did not exist.