### PR TITLE
fixes https://github.com/PlaytikaOSS/feign-reactive/issues/508

### DIFF
--- a/feign-reactor-core/src/main/java/reactivefeign/utils/CollectionUtils.java
+++ b/feign-reactor-core/src/main/java/reactivefeign/utils/CollectionUtils.java
@@ -1,0 +1,10 @@
+package reactivefeign.utils;
+
+import java.util.Collection;
+
+public class CollectionUtils {
+
+    public static <E> boolean isEmpty(Collection<E> c){
+        return c == null || c.isEmpty();
+    }
+}


### PR DESCRIPTION
Java11ReactiveHttpClient ignores presence of Content-Type header and attempts to add its own