### PR TITLE
WebReactiveFeign.Builder: use 'errorMapper' from configuration

### DIFF
--- a/feign-reactor-webclient/src/main/java/reactivefeign/webclient/WebReactiveFeign.java
+++ b/feign-reactor-webclient/src/main/java/reactivefeign/webclient/WebReactiveFeign.java
@@ -22,6 +22,7 @@ import reactivefeign.client.ReactiveHttpRequest;
 import reactivefeign.client.ReadTimeoutException;
 import reactor.netty.http.client.HttpClient;
 
+import java.util.Objects;
 import java.util.function.BiFunction;
 
 import static reactivefeign.webclient.NettyClientHttpConnectorBuilder.buildNettyClientHttpConnector;
@@ -78,13 +79,13 @@ public class WebReactiveFeign {
 
         @Override
         public BiFunction<ReactiveHttpRequest, Throwable, Throwable> errorMapper(){
-            return (request, throwable) -> {
-                if(throwable instanceof WebClientRequestException
-                   && throwable.getCause() instanceof io.netty.handler.timeout.ReadTimeoutException){
+            return Objects.requireNonNullElseGet(this.errorMapper, () -> (request, throwable) -> {
+                if (throwable instanceof WebClientRequestException
+                        && throwable.getCause() instanceof io.netty.handler.timeout.ReadTimeoutException) {
                     return new ReadTimeoutException(throwable, request);
                 }
                 return null;
-            };
+            });
         }
     }
 


### PR DESCRIPTION
# Problem
An 'errorMapper' provided via client configuration (ReactiveFeignBasicConfigurator) is ignored when it creates a client (WebReactiveHttpClient).

# Fix
To check if 'errorMapper' is defined. If not, it usesthe default BiFunction.