### PR TITLE
Allow customization of underlying Netty HttpClient

### DIFF
--- a/feign-reactor-spring-configuration/src/main/java/reactivefeign/spring/config/ReactiveFeignClientsConfiguration.java
+++ b/feign-reactor-spring-configuration/src/main/java/reactivefeign/spring/config/ReactiveFeignClientsConfiguration.java
@@ -44,6 +44,7 @@ import reactivefeign.java11.HttpClientFeignCustomizer;
 import reactivefeign.java11.Java11ReactiveFeign;
 import reactivefeign.jetty.JettyHttpClientFactory;
 import reactivefeign.jetty.JettyReactiveFeign;
+import reactivefeign.webclient.NettyHttpClientCustomizer;
 import reactivefeign.webclient.WebClientFeignCustomizer;
 import reactivefeign.webclient.WebReactiveFeign;
 
@@ -133,10 +134,15 @@ public class ReactiveFeignClientsConfiguration {
 			@Scope("prototype")
 			public ReactiveFeignBuilder reactiveFeignBuilder(
 					WebClient.Builder builder,
-					@Autowired(required = false) WebClientFeignCustomizer webClientCustomizer) {
-				return webClientCustomizer != null
+					@Autowired(required = false) WebClientFeignCustomizer webClientCustomizer,
+					@Autowired(required = false) List<NettyHttpClientCustomizer> nettyHttpClientCustomizers) {
+				WebReactiveFeign.Builder webReactiveFeignBuilder = webClientCustomizer != null
 						? WebReactiveFeign.builder(builder, webClientCustomizer)
 						: WebReactiveFeign.builder(builder);
+				if (nettyHttpClientCustomizers != null) {
+					nettyHttpClientCustomizers.forEach(webReactiveFeignBuilder::addCustomizer);
+				}
+				return webReactiveFeignBuilder;
 			}
 		}
 

--- a/feign-reactor-webclient/src/main/java/reactivefeign/webclient/NettyClientHttpConnectorBuilder.java
+++ b/feign-reactor-webclient/src/main/java/reactivefeign/webclient/NettyClientHttpConnectorBuilder.java
@@ -18,6 +18,7 @@ import reactor.netty.transport.ProxyProvider;
 
 import javax.net.ssl.SSLException;
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -32,7 +33,8 @@ class NettyClientHttpConnectorBuilder {
     private NettyClientHttpConnectorBuilder() {
     }
 
-    public static ClientHttpConnector buildNettyClientHttpConnector(HttpClient httpClient, WebReactiveOptions webOptions) {
+    public static ClientHttpConnector buildNettyClientHttpConnector(
+            HttpClient httpClient, WebReactiveOptions webOptions, List<NettyHttpClientCustomizer> customizers) {
 
         if (httpClient == null) {
 
@@ -127,6 +129,12 @@ class NettyClientHttpConnectorBuilder {
                 httpClient = httpClient.secure(sslProviderBuilder -> sslProviderBuilder.sslContext(sslContext));
             } catch (SSLException e) {
                 LOG.warn("Error creating SSLContext. The WebClient will verify all new HTTPS calls", e);
+            }
+        }
+
+        if (customizers != null) {
+            for (NettyHttpClientCustomizer customizer : customizers) {
+                httpClient = customizer.apply(httpClient);
             }
         }
 

--- a/feign-reactor-webclient/src/main/java/reactivefeign/webclient/NettyHttpClientCustomizer.java
+++ b/feign-reactor-webclient/src/main/java/reactivefeign/webclient/NettyHttpClientCustomizer.java
@@ -1,0 +1,8 @@
+package reactivefeign.webclient;
+
+import reactor.netty.http.client.HttpClient;
+
+import java.util.function.Function;
+
+public interface NettyHttpClientCustomizer extends Function<HttpClient, HttpClient> {
+}

--- a/feign-reactor-webclient/src/main/java/reactivefeign/webclient/WebReactiveFeign.java
+++ b/feign-reactor-webclient/src/main/java/reactivefeign/webclient/WebReactiveFeign.java
@@ -22,6 +22,8 @@ import reactivefeign.client.ReactiveHttpRequest;
 import reactivefeign.client.ReadTimeoutException;
 import reactor.netty.http.client.HttpClient;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.BiFunction;
 
@@ -52,6 +54,7 @@ public class WebReactiveFeign {
 
         private HttpClient httpClient;
         private WebReactiveOptions options = WebReactiveOptions.DEFAULT_OPTIONS;
+        private final List<NettyHttpClientCustomizer> nettyHttpClientCustomizers = new ArrayList<>();
 
         protected Builder(WebClient.Builder webClientBuilder) {
             super(webClientBuilder);
@@ -66,6 +69,11 @@ public class WebReactiveFeign {
             return this;
         }
 
+        public Builder<T> addCustomizer(NettyHttpClientCustomizer customizer){
+            this.nettyHttpClientCustomizers.add(customizer);
+            return this;
+        }
+
         @Override
         public Builder<T> options(ReactiveOptions options) {
             this.options = (WebReactiveOptions) options;
@@ -74,7 +82,7 @@ public class WebReactiveFeign {
 
         @Override
         protected ClientHttpConnector clientConnector() {
-            return buildNettyClientHttpConnector(httpClient, options);
+            return buildNettyClientHttpConnector(httpClient, options, nettyHttpClientCustomizers);
         }
 
         @Override

--- a/feign-reactor-webclient/src/test/java/reactivefeign/webclient/ClientCustomizerTest.java
+++ b/feign-reactor-webclient/src/test/java/reactivefeign/webclient/ClientCustomizerTest.java
@@ -1,0 +1,56 @@
+package reactivefeign.webclient;
+
+import feign.RequestLine;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        properties = {"spring.main.web-application-type=reactive"},
+        classes = {ClientCustomizerTest.TestController.class },
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@EnableAutoConfiguration
+public class ClientCustomizerTest {
+
+    @LocalServerPort
+    private int port;
+
+    private TestApi client;
+
+    @Before
+    public void setUp() {
+        client = WebReactiveFeign.<TestApi>builder()
+                .addCustomizer(httpClient -> httpClient.headers(h -> h.add("X-Custom", "value")))
+                .target(TestApi.class, "http://localhost:" + port);
+    }
+
+    @Test
+    public void shouldCustomizeClient() {
+        StepVerifier.create(client.test())
+                .expectNext("value")
+                .verifyComplete();
+    }
+
+    @RestController
+    public static class TestController {
+        @GetMapping("/test")
+        public Mono<String> test(@RequestHeader("X-Custom") String customHeader) {
+            return Mono.just(customHeader);
+        }
+    }
+
+    interface TestApi {
+        @RequestLine("GET /test")
+        Mono<String> test();
+    }
+}


### PR DESCRIPTION
Implemented feature request https://github.com/PlaytikaOSS/feign-reactive/issues/690 to allow customization of the underlying Netty HttpClient.
This is achieved by adding a clientCustomizer field (Function<HttpClient, HttpClient>) to WebReactiveOptions and applying it in NettyClientHttpConnectorBuilder.
Users can now provide a customizer via WebReactiveOptions.Builder to tweak the HttpClient configuration (e.g., DNS resolver, timeouts, etc.) beyond what was previously exposed.
Added integration test ClientCustomizerTest to verify that the customizer is applied correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customization mechanism for Netty HTTP client to allow modification of client behavior and configuration
  * Clients can now register custom handlers for HTTP client setup

* **Tests**
  * Added test demonstrating custom request header injection in HTTP requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->