### PR TITLE
Implement tests for ContentType and FormUtils

### DIFF
--- a/feign-reactor-core/src/main/java/reactivefeign/utils/ContentType.java
+++ b/feign-reactor-core/src/main/java/reactivefeign/utils/ContentType.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public class ContentType {
 
     private static final Pattern charsetPattern = Pattern
-            .compile("(?i)\\bcharset=\\s*\"?([^\\s;\"/]*)/?>");
+            .compile("(?i)\\bcharset=\\s*\"?([^\\s;\"/>]*)[\"?/>]?");
 
 
     private final String mediaType;

--- a/feign-reactor-core/src/main/java/reactivefeign/utils/ContentType.java
+++ b/feign-reactor-core/src/main/java/reactivefeign/utils/ContentType.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 public class ContentType {
 
     private static final Pattern charsetPattern = Pattern
-            .compile("(?i)\\bcharset=\\s*\"?([^\\s;\"/>]*)[\"?/>]?");
+            .compile("(?i)\\bcharset=\\s*\"?([^\\s;\"/>]*)");
 
 
     private final String mediaType;

--- a/feign-reactor-core/src/test/java/reactivefeign/utils/ContentTypeTest.java
+++ b/feign-reactor-core/src/test/java/reactivefeign/utils/ContentTypeTest.java
@@ -2,15 +2,44 @@ package reactivefeign.utils;
 
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class ContentTypeTest {
 
     @Test
     public void shouldParseContentTypeWoCharset() {
-        //TODO
+        ContentType contentType = ContentType.parse("application/json");
+        assertThat(contentType.getMediaType()).isEqualTo("application/json");
+        assertThat(contentType.getCharset()).isEqualTo(StandardCharsets.UTF_8);
     }
 
     @Test
     public void shouldParseContentTypeWithCharset() {
-        //TODO
+        ContentType contentType = ContentType.parse("application/json; charset=utf-8");
+        assertThat(contentType.getMediaType()).isEqualTo("application/json");
+        assertThat(contentType.getCharset()).isEqualTo(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void shouldParseContentTypeWithCharsetQuoted() {
+        ContentType contentType = ContentType.parse("application/json; charset=\"UTF-8\"");
+        assertThat(contentType.getMediaType()).isEqualTo("application/json");
+        assertThat(contentType.getCharset()).isEqualTo(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    public void shouldParseContentTypeWithDifferentCharset() {
+        ContentType contentType = ContentType.parse("text/plain; charset=iso-8859-1");
+        assertThat(contentType.getMediaType()).isEqualTo("text/plain");
+        assertThat(contentType.getCharset()).isEqualTo(StandardCharsets.ISO_8859_1);
+    }
+
+    @Test
+    public void shouldParseContentTypeWithUnsupportedCharset() {
+        ContentType contentType = ContentType.parse("application/json; charset=wrong");
+        assertThat(contentType.getMediaType()).isEqualTo("application/json");
+        assertThat(contentType.getCharset()).isEqualTo(StandardCharsets.UTF_8);
     }
 }

--- a/feign-reactor-core/src/test/java/reactivefeign/utils/FormUtilsTest.java
+++ b/feign-reactor-core/src/test/java/reactivefeign/utils/FormUtilsTest.java
@@ -1,6 +1,65 @@
 package reactivefeign.utils;
 
+import org.junit.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class FormUtilsTest {
 
-    //TODO
+    @Test
+    public void shouldSerializeSimpleForm() {
+        Map<String, Object> form = new LinkedHashMap<>();
+        form.put("key1", "value1");
+        form.put("key2", "value2");
+
+        SerializedFormData serialized = FormUtils.serializeForm(form, StandardCharsets.UTF_8);
+
+        assertThat(serialized.getFormDataString()).isEqualTo("key1=value1&key2=value2");
+    }
+
+    @Test
+    public void shouldSerializeFormWithCollection() {
+        Map<String, Object> form = new LinkedHashMap<>();
+        form.put("key", Arrays.asList("value1", "value2"));
+
+        SerializedFormData serialized = FormUtils.serializeForm(form, StandardCharsets.UTF_8);
+
+        assertThat(serialized.getFormDataString()).isEqualTo("key=value1&key=value2");
+    }
+
+    @Test
+    public void shouldSerializeFormWithSpecialCharacters() {
+        Map<String, Object> form = new LinkedHashMap<>();
+        form.put("key ", "value&");
+
+        SerializedFormData serialized = FormUtils.serializeForm(form, StandardCharsets.UTF_8);
+
+        assertThat(serialized.getFormDataString()).isEqualTo("key+=value%26");
+    }
+
+    @Test
+    public void shouldSerializeFormWithNullValue() {
+        Map<String, Object> form = new LinkedHashMap<>();
+        form.put("key", null);
+
+        SerializedFormData serialized = FormUtils.serializeForm(form, StandardCharsets.UTF_8);
+
+        assertThat(serialized.getFormDataString()).isEqualTo("key");
+    }
+
+    @Test
+    public void shouldSerializeFormWithDifferentCharset() {
+        Map<String, Object> form = new LinkedHashMap<>();
+        form.put("key", "value");
+
+        SerializedFormData serialized = FormUtils.serializeForm(form, StandardCharsets.ISO_8859_1);
+
+        assertThat(serialized.getFormDataString()).isEqualTo("key=value");
+        assertThat(serialized.getFormData()).isEqualTo(StandardCharsets.ISO_8859_1.encode("key=value"));
+    }
 }


### PR DESCRIPTION
I have implemented the requested unit tests for `ContentType` and `FormUtils` utility classes in the `feign-reactor-core` module.

During the implementation, I identified and fixed a bug in the charset parsing regex in `ContentType.java` which failed to correctly parse quoted charset values (e.g., `charset="UTF-8"`) and was too restrictive about trailing characters.

The new tests cover:
- `ContentType`: parsing with/without charset, quoted charsets, different charsets, and unsupported charsets.
- `FormUtils`: simple forms, collections, URL encoding of special characters, null values, and custom charsets.

All temporary manual verification tools and accidental binary files have been removed from the final submission.

---
*PR created automatically by Jules for task [3112091859909603494](https://jules.google.com/task/3112091859909603494) started by @Periecle*