### PR TITLE
🧪 [Testing Improvement] Edge case test and fix in AbstractReactiveFeignConfigurator

### DIFF
--- a/feign-reactor-spring-configuration/src/main/java/reactivefeign/spring/config/AbstractReactiveFeignConfigurator.java
+++ b/feign-reactor-spring-configuration/src/main/java/reactivefeign/spring/config/AbstractReactiveFeignConfigurator.java
@@ -10,6 +10,9 @@ abstract public class AbstractReactiveFeignConfigurator implements ReactiveFeign
 
     @Override
     public int compareTo(ReactiveFeignConfigurator configurator){
+        if (this == configurator) {
+            return 0;
+        }
         int compare = Integer.compare(order, ((AbstractReactiveFeignConfigurator) configurator).order);
         if(compare == 0){
             throw new IllegalArgumentException(String.format("Same order for different configurators: [%s], [%s]",

--- a/feign-reactor-spring-configuration/src/test/java/reactivefeign/spring/config/AbstractReactiveFeignConfiguratorTest.java
+++ b/feign-reactor-spring-configuration/src/test/java/reactivefeign/spring/config/AbstractReactiveFeignConfiguratorTest.java
@@ -1,0 +1,58 @@
+package reactivefeign.spring.config;
+
+import org.junit.Test;
+import reactivefeign.ReactiveFeignBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AbstractReactiveFeignConfiguratorTest {
+
+    @Test
+    public void shouldCompareSameInstance() {
+        TestConfigurator configurator = new TestConfigurator(1);
+        assertThat(configurator.compareTo(configurator)).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldCompareDifferentOrder() {
+        TestConfigurator configurator1 = new TestConfigurator(1);
+        TestConfigurator configurator2 = new TestConfigurator(2);
+
+        assertThat(configurator1.compareTo(configurator2)).isLessThan(0);
+        assertThat(configurator2.compareTo(configurator1)).isGreaterThan(0);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenSameOrder() {
+        TestConfigurator configurator1 = new TestConfigurator(1);
+        TestConfigurator configurator2 = new TestConfigurator(1);
+
+        assertThatThrownBy(() -> configurator1.compareTo(configurator2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Same order for different configurators");
+    }
+
+    @Test
+    public void shouldBeTransitive() {
+        TestConfigurator configurator1 = new TestConfigurator(1);
+        TestConfigurator configurator2 = new TestConfigurator(2);
+        TestConfigurator configurator3 = new TestConfigurator(3);
+
+        // Verifies that if c1 < c2 and c2 < c3, then c1 < c3
+        assertThat(configurator1.compareTo(configurator2)).isLessThan(0);
+        assertThat(configurator2.compareTo(configurator3)).isLessThan(0);
+        assertThat(configurator1.compareTo(configurator3)).isLessThan(0);
+    }
+
+    private static class TestConfigurator extends AbstractReactiveFeignConfigurator {
+        protected TestConfigurator(int order) {
+            super(order);
+        }
+
+        @Override
+        public ReactiveFeignBuilder configure(ReactiveFeignBuilder builder, ReactiveFeignNamedContext namedContext) {
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Addressed PR feedback by adding a test for transitivity in `AbstractReactiveFeignConfiguratorTest`.
📊 **Coverage:** Added `shouldBeTransitive` test case, ensuring that reflexivity, anti-symmetry, and transitivity of the `Comparable` contract are all verified.
✨ **Result:** Improved the robustness of the configurator's comparison logic testing.

---
*PR created automatically by Jules for task [14191844338616150843](https://jules.google.com/task/14191844338616150843) started by @Periecle*