### PR TITLE
Migrate to Spring Boot 3.5

### DIFF
--- a/feign-reactor-parent/pom.xml
+++ b/feign-reactor-parent/pom.xml
@@ -18,8 +18,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!--BOMs-->
-        <spring-cloud-bom.version>2023.0.2</spring-cloud-bom.version>
-        <spring-boot-dependencies-bom.version>3.2.7</spring-boot-dependencies-bom.version>
+        <spring-cloud-bom.version>2025.0.0</spring-cloud-bom.version>
+        <spring-boot-dependencies-bom.version>3.5.0</spring-boot-dependencies-bom.version>
 
         <!--other-->
         <json-reactor.version>0.0.4</json-reactor.version>


### PR DESCRIPTION
This PR upgrades the `spring-boot-dependencies-bom` version to `3.5.0` and the corresponding `spring-cloud-bom` version to `2025.0.0` in the `feign-reactor-parent/pom.xml`. Tests were successfully verified against the modified modules.

---
*PR created automatically by Jules for task [7711608066783325885](https://jules.google.com/task/7711608066783325885) started by @Periecle*